### PR TITLE
[Needs Review] [Typo Fix] - `Carrot` should be lowercase.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It turned out really well and I am putting the recipe online to make it easy to 
 - ~400g Habanero Chilis
 - ~250g Piri Piri Chilis (exchange with Cayennes, Birds Eye or similar)
 - A couple of yellow Jalapeño peppers for mild fruity heat (optional. I had them laying around)
-- One large Carrot (~160g)
+- One large carrot (~160g)
 - One large parsnip (~130g)
 - Three garlic cloves
 - 5% Brine --> __Per Liter__; 950g chlorine free water, 50g salt without additives (sea salt, rock salt or kosher salt)


### PR DESCRIPTION
`One large Carrot` => `One large carrot`